### PR TITLE
Changed cropping coordinates method, code cleanup

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,15 +1,13 @@
 # path of tesseract executable
-TESSERACT_PATH: C:\example\Tesseract\tesseract.exe
-# name (and path) of video to analyze
-VIDEO_NAME: vid.mp4
+TESSERACT_PATH: \tesseract.exe
 # tolerance in comparing 2 frames
 TOLERANCE: 1
 # number of frames to skip after every read frame
 READ_EVERY_N_FRAMES: 10
 # frame to start analisys
 START_FRAME: 0
-# coords to crop frame only to read the number
-# [start_row,end_row,start_col,end_col]
-IMG_CROP_BORDERS: [1000,1070,1600,1660]
+# coords to crop frame to read slide number (in %width, %height)
+# [x1,y1,x2,y2]
+IMG_CROP_BORDERS: [83.5,93,87,99]
 # path to save
 SLIDES_PATH: slides

--- a/config/config.yml
+++ b/config/config.yml
@@ -8,6 +8,8 @@ READ_EVERY_N_FRAMES: 10
 START_FRAME: 0
 # coords to crop frame to read slide number (in %width, %height)
 # [x1,y1,x2,y2]
-IMG_CROP_BORDERS: [83.5,93,87,99]
+NUMBER_CROP_BORDERS: [83.5,93,87,99]
+# coords to crop the final slide (e.g. to remove black bars)
+IMG_CROP_BORDERS: [13,0,87,100]
 # path to save
 SLIDES_PATH: slides

--- a/saveslide.py
+++ b/saveslide.py
@@ -3,9 +3,7 @@ import pytesseract
 import numpy as np
 import yaml
 
-# funzioni
-
-def isDifferent(img1, img2,errore) -> bool:
+def _isDifferent(img1, img2,errore: int) -> bool:
     '''
     determina se la differenza tra le immagini è maggiore di errore
     '''
@@ -14,67 +12,84 @@ def isDifferent(img1, img2,errore) -> bool:
     diff = cv2.subtract(img1, img2)
     err = np.sum(diff**2)
     mse = err/(float(h*w))
-    #print(mse)
     return mse>errore
 
-def cropped(frame,bordo):
+def _cropped(frame,bordo: list):
     '''
-    ritorna il frame croppato secondo l'array bordo
+    ritorna il frame croppato secondo la lista bordo
     0: riga iniziale 1: riga finale
     2: colonna iniziale 3: colonna finale
     '''
     return frame[bordo[0]:bordo[1],bordo[2]:bordo[3]]
 
-def getSlidenumber(frame) -> int:
+def _getSlidenumber(frame) -> int:
     '''
     ritorna il numero letto nel frame
     '''
     num = pytesseract.image_to_string(frame, config='--psm 10 --oem 3 -c tessedit_char_whitelist=0123456789abcdefghijklmnopqrstuvwxyz')
     return num
 
-# definizione variabili e init classi
 
-config = yaml.safe_load(open('config/config.yml', 'rb'))# file config
 
-pytesseract.pytesseract.tesseract_cmd = config['TESSERACT_PATH']
+def _getBorder(borderperc: list,framedim: list) -> list:
+    '''
+    ritorna le coordinate del bordo formattate secondo lo standard della funzione _cropped
+    '''
+    maplist = [[1,1],[3,1],[0,0],[2,0]]
+    '''
+    maplist indica: i[0] il corrispondente indice in borderperc
+    i[1] se considerare altezza o larghezza
+    '''
+    return [int(borderperc[i[0]]*framedim[i[1]]/100) for i in maplist]
 
-vidcap = cv2.VideoCapture(config['VIDEO_NAME'])
+def run(video_path:str):
+    '''
+    saves slides from 'video_path'
+    '''
+    # definizione variabili e init classi
 
-frames = vidcap.get(cv2.CAP_PROP_FRAME_COUNT)           # frame totali
-fps = vidcap.get(cv2.CAP_PROP_FPS)
+    config = yaml.safe_load(open('config/config.yml', 'rb'))# file config
 
-bordo_std = config['IMG_CROP_BORDERS']                  # per cropping sul numero
-skipFrames = config['READ_EVERY_N_FRAMES']              # controlla solo un frame ogni 'skipFrames'
-errore = config['TOLERANCE']                            # tolleranza confronto slide
-startFrame = config['START_FRAME']
-frameSkipper = 1
-c = startFrame
-numeriSlide = []                                        # lista per evitare ripetizioni di slide
-vidcap.set(cv2.CAP_PROP_POS_FRAMES, c)                  # imposta frame iniziale
+    pytesseract.pytesseract.tesseract_cmd = config['TESSERACT_PATH']
 
-isFrame, lastFrame = vidcap.read()                      # init del primo frame
+    vidcap = cv2.VideoCapture(video_path)
 
-# main loop
+    frames = vidcap.get(cv2.CAP_PROP_FRAME_COUNT)           # frame totali
+    fps = vidcap.get(cv2.CAP_PROP_FPS)
+    dim = [vidcap.get(cv2.CAP_PROP_FRAME_WIDTH),vidcap.get(cv2.CAP_PROP_FRAME_HEIGHT)]
+    bordo_std = _getBorder(config['IMG_CROP_BORDERS'],dim)       # per cropping sul numero
+    skipFrames = config['READ_EVERY_N_FRAMES']              # controlla solo un frame ogni 'skipFrames'
+    errore = config['TOLERANCE']                            # tolleranza confronto slide
+    startFrame = config['START_FRAME']
+    frameSkipper = 1
+    c = startFrame
+    numeriSlide = []                                        # lista per evitare ripetizioni di slide
+    vidcap.set(cv2.CAP_PROP_POS_FRAMES, c)                  # imposta frame iniziale
 
-while c<frames:
-    print('\033[K','\r{}s/{}s  slides salvate: {}'.format(round(c/fps),round(frames/fps),numeriSlide),end='') # avanzamento
-    c+=1
-    isFrame, nextFrame = vidcap.read() # legge frame
+    lastFrame = vidcap.read()[1]                      # init del primo frame
 
-    if frameSkipper<skipFrames:
-        frameSkipper+=1
-        continue
-    else:
-        frameSkipper=1
-        try:
-            if isDifferent(cropped(lastFrame,bordo_std),cropped(nextFrame,bordo_std),errore): # controlla similitudine
-                slidenum = int(getSlidenumber(cropped(nextFrame,bordo_std))) # controlla numero
+    # main loop
+    while c<frames:
+        print('\033[K','\r{}s/{}s  slides salvate: {}'.format(round(c/fps),round(frames/fps),numeriSlide),end='') # avanzamento
+        c+=1
+        nextFrame = vidcap.read()[1] # legge frame
+
+        if frameSkipper<skipFrames:
+            frameSkipper+=1
+            continue
+        else:
+            frameSkipper=1
+            try:
+                if _isDifferent(_cropped(lastFrame,bordo_std),_cropped(nextFrame,bordo_std),errore): # controlla similitudine
+                    slidenum = int(_getSlidenumber(_cropped(nextFrame,bordo_std))) # controlla numero
+                    
+                if slidenum not in numeriSlide: # se la slide non è ancora apparsa
+                    nextFrame = vidcap.read()[1] # skippa un frame per evitare slide blurrate
+                    # orribile ma più veloce di 'vidcap.set(cv2.CAP_PROP_POS_FRAMES, frame)' soprattutto con 1 solo frame skip
+                    cv2.imwrite('{}\slide{}.png'.format(config['SLIDES_PATH'],slidenum),nextFrame) #salva frame successivo
+                    numeriSlide.append(slidenum)
+            except Exception as e:
+                #print(e)
+                pass
                 
-            if slidenum not in numeriSlide: # se la slide non è ancora apparsa
-                cv2.imwrite('{}\slide{}.png'.format(config['SLIDES_PATH'],slidenum),nextFrame) #salva frame successivo
-                numeriSlide.append(slidenum)
-        except Exception as e:
-            #print(e)
-            pass
-            
-    lastFrame = nextFrame # next frame diventa lastFrame
+        lastFrame = nextFrame # next frame diventa lastFrame

--- a/saveslide.py
+++ b/saveslide.py
@@ -57,7 +57,8 @@ def run(video_path:str):
     frames = vidcap.get(cv2.CAP_PROP_FRAME_COUNT)           # frame totali
     fps = vidcap.get(cv2.CAP_PROP_FPS)
     dim = [vidcap.get(cv2.CAP_PROP_FRAME_WIDTH),vidcap.get(cv2.CAP_PROP_FRAME_HEIGHT)]
-    bordo_std = _getBorder(config['IMG_CROP_BORDERS'],dim)       # per cropping sul numero
+    bordo_std = _getBorder(config['NUMBER_CROP_BORDERS'],dim)       # per cropping sul numero
+    bordo_slide = _getBorder(config['IMG_CROP_BORDERS'],dim)        # per cropping slide definitiva
     skipFrames = config['READ_EVERY_N_FRAMES']              # controlla solo un frame ogni 'skipFrames'
     errore = config['TOLERANCE']                            # tolleranza confronto slide
     startFrame = config['START_FRAME']
@@ -86,7 +87,7 @@ def run(video_path:str):
                 if slidenum not in numeriSlide: # se la slide non è ancora apparsa
                     nextFrame = vidcap.read()[1] # skippa un frame per evitare slide blurrate
                     # orribile ma più veloce di 'vidcap.set(cv2.CAP_PROP_POS_FRAMES, frame)' soprattutto con 1 solo frame skip
-                    cv2.imwrite('{}\slide{}.png'.format(config['SLIDES_PATH'],slidenum),nextFrame) #salva frame successivo
+                    cv2.imwrite('{}\slide{}.png'.format(config['SLIDES_PATH'],slidenum),_cropped(nextFrame,bordo_slide)) #salva frame successivo
                     numeriSlide.append(slidenum)
             except Exception as e:
                 #print(e)


### PR DESCRIPTION
- Cropping coordinates are now passed as two points expressed as a percentage of width and height respectively:
`NUMBER_CROP_BORDERS: [x1,y1,x2,y2]`
- Added run() function to ease the call from other scripts.
- Added ability to crop slide via `IMG_CROP_BORDERS` using same method as `NUMBER_CROP_BORDERS`